### PR TITLE
Update ChemVend inventory for better balance

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -3,25 +3,25 @@
   startingInventory:
     Jug: 4
     JugAluminium: 2
-    JugCarbon: 2
-    JugChlorine: 2
+    JugCarbon: 4
+    JugChlorine: 1
     JugCopper: 2
     JugEthanol: 2
-    JugFluorine: 2
-    JugHydrogen: 2
-    JugIodine: 2
+    JugFluorine: 1
+    JugHydrogen: 3
+    JugIodine: 1
     JugIron: 2
     JugLithium: 2
-    JugMercury: 2
-    JugNitrogen: 2
-    JugOxygen: 2
-    JugPhosphorus: 2
+    JugMercury: 1
+    JugNitrogen: 3
+    JugOxygen: 3
+    JugPhosphorus: 1
     JugPotassium: 2
-    JugRadium: 2
+    JugRadium: 1
     JugSilicon: 2
     JugSodium: 2
     JugSugar: 2
-    JugSulfur: 2
+    JugSulfur: 1
   emaggedInventory:
     ToxinChemistryBottle: 1
 
@@ -30,25 +30,25 @@
   startingInventory:
     Jug: 4
     JugAluminium: 2
-    JugCarbon: 2
-    JugChlorine: 2
+    JugCarbon: 4
+    JugChlorine: 1
     JugCopper: 2
     JugEthanol: 2
-    JugFluorine: 2
-    JugHydrogen: 2
-    JugIodine: 2
+    JugFluorine: 1
+    JugHydrogen: 3
+    JugIodine: 1
     JugIron: 2
     JugLithium: 2
-    JugMercury: 2
-    JugNitrogen: 2
-    JugOxygen: 2
-    JugPhosphorus: 2
+    JugMercury: 1
+    JugNitrogen: 3
+    JugOxygen: 3
+    JugPhosphorus: 1
     JugPotassium: 2
-    JugRadium: 2
+    JugRadium: 1
     JugSilicon: 2
     JugSodium: 2
     JugSugar: 2
-    JugSulfur: 2
+    JugSulfur: 1
     JugWeldingFuel: 1
   emaggedInventory:
     PaxChemistryBottle: 3


### PR DESCRIPTION
## About the PR
I rebalanced what comes in the ChemVend and the ChemVend refills to be closer to actual usage levels by the average chemist

## Why / Balance
You do not need as much Radium as you do carbon. It's silly to get the same amounts of every chem when some are used for almost everything, and some have basically no use. 

I'm not a Chemist main or anything so if some of these numbers look off to you, feel free to tweak them. But this is based on several shifts of my chem experience

## Technical details
Just changed the numbers in a .yml, nothing fancy at all

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None, it's just a quantity swap.

**Changelog**
Rebalanced ChemVend stock for more accurate usage levels
